### PR TITLE
Mirror "root" functionality for leaf nodes

### DIFF
--- a/dev/api.lisp
+++ b/dev/api.lisp
@@ -550,9 +550,20 @@ as a source. [?? Could be a defun]."))
   are out-going\). (cf. rootp) [?? could be a defun]"))
 
 
+(defgeneric graph-leafs (graph)
+  (:documentation "Returns a list of the leafs of graph. A leaf is
+  defined as a vertex with no target edges \(i.e., all of the edges
+  are incoming\). (cf. targetp) [?? could be a defun]"))
+
+
 (defgeneric rootp (vertex)
   (:documentation "Returns true if `vertex` is a root vertex \(i.e.,
   it has no incoming \(source\) edges\)."))
+
+
+(defgeneric leafp (vertex)
+  (:documentation "Returns true if `vertex` is a leaf vertex \(i.e.,
+  it has no outgoing \(target\) edges\)."))
 
 
 (defgeneric find-vertex-if (thing predicate &key key)

--- a/dev/graph.lisp
+++ b/dev/graph.lisp
@@ -644,9 +644,17 @@ something is putting something on the vertexes plist's
   (collect-elements (graph-vertexes graph) :filter #'rootp))
 
 
+(defmethod graph-leafs ((graph basic-graph))
+  (collect-elements (graph-vertexes graph) :filter #'leafp))
+
+
 (defmethod rootp ((vertex basic-vertex))
   ;;?? this is inefficient in the same way that (zerop (length <list>)) is...
   (zerop (target-edge-count vertex)))
+
+
+(defmethod leafp ((vertex basic-vertex))
+  (zerop (source-edge-count vertex)))
 
 
 (defmethod find-vertex-if ((graph basic-graph) fn &key key)

--- a/dev/package.lisp
+++ b/dev/package.lisp
@@ -46,7 +46,9 @@ DISCUSSION
    #:target-edge-count             ; vertex
    
    #:rootp                         ; vertex
+   #:leafp                         ; vertex
    #:graph-roots                   ; graph
+   #:graph-leafs                   ; graph
    
    #:topological-sort              ; graph
    #:depth                         ; graph | vertex


### PR DESCRIPTION
Defines two new functions: graph-leafs and leafp. These are similar to
graph-roots and rootp but act on leaf nodes instead.
