### PR TITLE
Undirected edge handling

### DIFF
--- a/dev/graph-container.lisp
+++ b/dev/graph-container.lisp
@@ -50,6 +50,16 @@ DISCUSSION
   (:export-p t)
   (:documentation "A weighted edge is both a weighted-edge-mixin and a graph-container-edge."))
 
+(defclass* weighted-directed-edge (weighted-edge-mixin graph-container-directed-edge)
+  ()
+  (:export-p t)
+  (:documentation "A weighted edge is a weighted-edge-mixin, a directed-edge-mixin, and a graph-container-edge."))
+
+(defclass* weighted-undirected-edge (weighted-edge-mixin graph-container-undirected-edge)
+  ()
+  (:export-p t)
+  (:documentation "A weighted undirected edge is a weighted-edge-mixin, an undirected-edge-mixin, and a graph-container-edge."))
+
 
 (defclass* graph-container-vertex (basic-vertex)
   ((vertex-edges nil r))
@@ -156,7 +166,7 @@ DISCUSSION
   (dissoc-val-from-key-or-delete (vertex-pair->edge graph)
 				 (cons (vertex-1 edge) (vertex-2 edge)) edge))
 
-(defmethod dissociate-edge-from-pair ((graph graph-container) (edge undirected-edge-mixin))
+(defmethod dissociate-edge-from-pair :after ((graph graph-container) (edge undirected-edge-mixin))
   (dissoc-val-from-key-or-delete (vertex-pair->edge graph)
 				 (cons (vertex-2 edge) (vertex-1 edge)) edge))
 

--- a/unit-tests/package.lisp
+++ b/unit-tests/package.lisp
@@ -1,4 +1,4 @@
 (in-package #:common-lisp-user)
 
 (defpackage #:cl-graph-test
-  (:use #:common-lisp #:cl-graph #:lift #:metatilities))
+  (:use #:common-lisp #:cl-graph #:lift #:metatilities #:cl-containers))

--- a/unit-tests/test-graph.lisp
+++ b/unit-tests/test-graph.lisp
@@ -27,8 +27,8 @@
 (addtest (test-test-vertex)
   test-2
   (let ((x (float 2.1d0))
-         (y (float 2.1d0))
-         (g (make-container 'graph-container :vertex-test #'=)))
+	(y (float 2.1d0))
+	(g (make-container 'graph-container :vertex-test '=)))
     (add-vertex g (+ x y))
     (add-vertex g (+ x y))
     


### PR DESCRIPTION
Undirected edges did not behave as expected; by putting the undirected edge in the vertex-pair table for both endvertex orders, expected behavior was obtained. This change does not break the existing tests, but isn't checked by further tests.