### PR TITLE
More system definition cleanups for ASDF 3.3

### DIFF
--- a/cl-graph+hu.dwim.graphviz.asd
+++ b/cl-graph+hu.dwim.graphviz.asd
@@ -1,6 +1,6 @@
-;;; -*- Mode: Lisp; package: cl-user; Syntax: Common-lisp; Base: 10 -*-
+;;; -*- Mode: Lisp; package: asdf-user; Syntax: Common-lisp; Base: 10 -*-
 
-(defsystem :cl-graph+hu.dwim.graphviz
+(defsystem "cl-graph+hu.dwim.graphviz"
   :author "Gary Warren King <gwking@metabang.com>"
   :maintainer "Gary Warren King <gwking@metabang.com>"
   :licence "MIT Style License"
@@ -10,5 +10,4 @@
                 ((:module "graphviz"
                   :components
                   ((:file "graphviz-support-optional"))))))
-  :depends-on (:cl-graph
-               :hu.dwim.graphviz))
+  :depends-on ("cl-graph" "hu.dwim.graphviz"))

--- a/cl-graph-test.asd
+++ b/cl-graph-test.asd
@@ -1,10 +1,6 @@
-;;; -*- Mode: Lisp; package: cl-user; Syntax: Common-lisp; Base: 10 -*-
+;;; -*- Mode: Lisp; package: asdf-user; Syntax: Common-lisp; Base: 10 -*-
 
-(in-package :common-lisp-user)
-(defpackage #:cl-graph-test-system (:use #:cl #:asdf))
-(in-package #:cl-graph-test-system)
-
-(defsystem cl-graph-test
+(defsystem "cl-graph-test"
   :author "Gary Warren King <gwking@metabang.com>"
   :maintainer "Gary Warren King <gwking@metabang.com>"
   :licence "MIT Style License"
@@ -16,7 +12,7 @@
 		((:file "package")
 		 (:file "test-graph" :depends-on ("package"))
 		 ))
-	       (:module 
+	       (:module
 		"unit-tests"
 		:pathname "unit-tests/"
 		:depends-on ("setup")
@@ -25,20 +21,14 @@
 		 (:file "test-connected-components")
 		 ;;(:file "test-graph-algorithms")
 		 (:file "test-api")
-		 ))
-               
-               (:module 
-		"dev"
-		:components
-		((:static-file "notes.text"))))
-  :depends-on (:cl-graph :lift))
+		 )))
+  :depends-on ("cl-graph" "lift"))
 
-;; 2008-09-24 - I don't know if this will work or not 
+;; 2008-09-24 - I don't know if this will work or not
 ;; i.e., will it happen at the right time wrt everything else
-#+asdf-system-connections
-(asdf:defsystem-connection cl-graph-test-and-cl-mathstats
-  :requires (cl-graph moptilities)
-  :components ((:module 
+(defsystem-connection "cl-graph-test/with-cl-mathstats"
+  :requires ("cl-graph" "moptilities")
+  :components ((:module
 		"unit-tests"
 		:components
 		((:file "test-graph-metrics")))))

--- a/cl-graph.asd
+++ b/cl-graph.asd
@@ -1,29 +1,15 @@
-;;; -*- Mode: Lisp; package: cl-user; Syntax: Common-lisp; Base: 10 -*-
+;;; -*- Mode: Lisp; package: asdf-user; Syntax: Common-lisp; Base: 10 -*-
 
-(in-package #:common-lisp-user)
-(defpackage #:cl-graph-system (:use #:cl #:asdf))
-(in-package #:cl-graph-system)
-
-(unless (or (member :asdf-system-connections *features*)
-	    (find-system 'asdf-system-connections nil))
-  (warn "The CL-Graph system would enjoy having asdf-system-connections 
-around. See 
-http://www.cliki.net/asdf-system-connections for details and download
-instructions."))
-(when (and (not (member :asdf-system-connections *features*))
-	   (find-system 'asdf-system-connections nil))
-  (operate 'load-op 'asdf-system-connections))
-
-(defsystem cl-graph
+(defsystem "cl-graph"
   :version "0.10.2"
   :author "Gary Warren King <gwking@metabang.com>"
   :maintainer "Gary Warren King <gwking@metabang.com>"
   :licence "MIT Style License"
   :description "Graph manipulation utilities for Common Lisp"
   :components ((:static-file "COPYING")
-	       (:module 
-		"dev"
-		:components 
+               (:module
+                "dev"
+                :components
 		((:file "package")
 		 (:file "api"
 			:depends-on ("package"))
@@ -44,72 +30,60 @@ instructions."))
 
 		 (:module "graphviz" :depends-on ("graph")
 			  :components ((:file "graphviz-support")))))
-               (:module 
-		"website"
-		:components 
+               (:module
+                "website"
+		:components
 		((:module "source"
-			  :components ((:static-file "index.md"))))))
-  :in-order-to ((test-op (load-op :cl-graph-test)))
-  :perform (test-op :after (op c)
-		    (funcall
-		      (intern (symbol-name '#:run-tests) :lift)
-		      :config :generic))
-  :depends-on ((:version :metatilities-base "0.6.0")
-	       (:version :cl-containers "0.12.0")
-	       :metabang-bind
-	       ))
+			  :components ((:static-file "index.mmd"))))))
+  :in-order-to ((test-op (load-op "cl-graph-test")))
+  :perform (test-op (op c) (symbol-call :lift :run-tests :config :generic))
+  :depends-on ((:version "metatilities-base" "0.6.0")
+               (:version "cl-containers" "0.12.0")
+               "metabang-bind"))
 
-(defmethod operation-done-p 
-           ((o test-op) (c (eql (find-system 'cl-graph))))
-  (values nil))
+(load-system "asdf-system-connections")
 
-#+asdf-system-connections
-(asdf:defsystem-connection cl-graph-and-cl-variates
-  :requires (cl-graph cl-variates)
-  :components ((:module 
+(defsystem-connection "cl-graph/with-cl-variates"
+  :requires ("cl-graph" "cl-variates")
+  :components ((:module
 		"dev"
 		:components
 		((:file "graph-and-variates")
 		 (:file "graph-generation"
 			:depends-on ("graph-and-variates"))))))
 
-#+asdf-system-connections
-(asdf:defsystem-connection cl-graph-and-dynamic-classes
-  :requires (cl-graph dynamic-classes)
-  :components ((:module 
+(defsystem-connection "cl-graph/with-dynamic-classes"
+  :requires ("cl-graph" "dynamic-classes")
+  :components ((:module
 		"dev"
 		:components
 		((:file "dynamic-classes")))))
 
-#+asdf-system-connections
-(asdf:defsystem-connection cl-graph-and-cl-graphviz
-  :requires (cl-graph cl-graphviz)
-  :components ((:module 
+(defsystem-connection "cl-graph/with-cl-graphviz"
+  :requires ("cl-graph" "cl-graphviz")
+  :components ((:module
 		"dev"
 		:components
 		((:module "graphviz"
 			  :components
 			  ((:file "graphviz-support-optional")))))))
 
-#+asdf-system-connections
-(asdf:defsystem-connection cl-graph-and-metacopy
-  :requires (cl-graph metacopy)
-  :components ((:module 
+(defsystem-connection "cl-graph/with-metacopy"
+  :requires ("cl-graph" "metacopy")
+  :components ((:module
 		"dev"
 		:components ((:file "copying")))))
 
-#+asdf-system-connections
-(asdf:defsystem-connection cl-graph-and-cl-mathstats
-  :requires (cl-graph cl-mathstats)
-  :components ((:module 
+(defsystem-connection "cl-graph/with-cl-mathstats"
+  :requires ("cl-graph" "cl-mathstats")
+  :components ((:module
 		"dev"
 		:components
 		((:file "graph-metrics")))))
 
-#+asdf-system-connections
-(asdf:defsystem-connection cl-graph-and-moptilities
-  :requires (cl-graph moptilities)
-  :components ((:module 
+(defsystem-connection "cl-graph/with-moptilities"
+  :requires ("cl-graph" "moptilities")
+  :components ((:module
 		"dev"
 		:components
 		((:file "subgraph-containing")))))


### PR DESCRIPTION
Most importantly, follow the naming conventions of secondary systems
so they don't cause ASDF to issue a warning.

Also, make asdf-system-connections not optional, since we probably
want those systems to always be defined. A yet cleaner alternative
would be to move those connections to a separate file
cl-graph-connections, but that's not backward compatible, so it's
not my decision to make.